### PR TITLE
Add Nix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Cachix
+        uses: cachix/cachix-action@v15
+        with:
+          name: justinmoon
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Run CI pipeline
+        run: nix run .#ci

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
           ];
 
           buildInputs = with pkgs; [
+            dav1d
             openssl
           ] ++ pkgs.lib.optionals stdenv.isDarwin [
             apple-sdk
@@ -82,12 +83,24 @@
           cargoTestArgs = "--test offline_test";
         });
 
+        ciScript = pkgs.writeShellApplication {
+          name = "frontier-ci";
+          runtimeInputs = [
+            pkgs.nix
+            pkgs.bash
+          ];
+          text = ''
+            exec nix develop .#default --command ${pkgs.bash}/bin/bash ${./scripts/ci.sh}
+          '';
+        };
+
       in
       {
         # Packages
         packages = {
           default = frontier;
           frontier = frontier;
+          ci = ciScript;
         };
 
         # Checks run by `nix flake check`
@@ -135,6 +148,11 @@
         apps.default = flake-utils.lib.mkApp {
           drv = frontier;
           name = "frontier";
+        };
+
+        apps.ci = flake-utils.lib.mkApp {
+          drv = ciScript;
+          name = "frontier-ci";
         };
       }
     );

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${FRONTIER_CI_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)}"
+
+if [[ ! -f "$ROOT_DIR/Cargo.toml" ]]; then
+  printf 'Unable to locate project root (missing Cargo.toml in %s)\n' "$ROOT_DIR" >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+run_step() {
+  local description="$1"
+  shift
+  printf '\n=== %s ===\n' "$description"
+  "$@"
+}
+
+run_step "Checking formatting" cargo fmt --all -- --check
+run_step "Checking build" cargo check --workspace --all-targets
+run_step "Running clippy" cargo clippy --all-targets --workspace -- -D warnings
+run_step "Running test suite" cargo test
+run_step "Running online tests" cargo test --test online_test -- --ignored
+
+printf '\nCI pipeline completed successfully.\n'

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ use anyrender_vello::VelloWindowRenderer as WindowRenderer;
 #[cfg(feature = "cpu-base")]
 use anyrender_vello_cpu::VelloCpuWindowRenderer as WindowRenderer;
 
-use blitz_dom::DocumentConfig;
 use blitz_dom::net::Resource;
+use blitz_dom::DocumentConfig;
 use blitz_html::HtmlDocument;
 use blitz_net::Provider;
 use blitz_traits::navigation::{NavigationOptions, NavigationProvider};
@@ -28,7 +28,7 @@ use notify::{Error as NotifyError, Event as NotifyEvent, RecursiveMode, Watcher 
 use readme_application::{ReadmeApplication, ReadmeEvent};
 
 use blitz_shell::{
-    BlitzShellEvent, BlitzShellNetCallback, WindowConfig, create_default_event_loop,
+    create_default_event_loop, BlitzShellEvent, BlitzShellNetCallback, WindowConfig,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -51,9 +51,9 @@ impl NavigationProvider for ReadmeNavigationProvider {
 }
 
 fn main() {
-    let raw_url = std::env::args().nth(1).unwrap_or_else(|| {
-        String::from("https://example.com")
-    });
+    let raw_url = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| String::from("https://example.com"));
 
     // Turn on the runtime and enter it
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/src/markdown/comrak.rs
+++ b/src/markdown/comrak.rs
@@ -1,6 +1,6 @@
 //! Render the readme.md using the gpu renderer
 
-use comrak::{ExtensionOptions, Options, Plugins, RenderOptions, markdown_to_html_with_plugins};
+use comrak::{markdown_to_html_with_plugins, ExtensionOptions, Options, Plugins, RenderOptions};
 
 pub(crate) fn markdown_to_html(contents: String) -> String {
     let plugins = Plugins::default();

--- a/src/readme_application.rs
+++ b/src/readme_application.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use crate::WindowRenderer;
-use blitz_dom::DocumentConfig;
 use blitz_dom::net::Resource;
+use blitz_dom::DocumentConfig;
 use blitz_html::HtmlDocument;
 use blitz_net::Provider;
 use blitz_shell::{BlitzApplication, BlitzShellEvent, View, WindowConfig};
@@ -104,7 +104,9 @@ impl ReadmeApplication {
         // Now fetch the actual target URL
         // Note: raw_url will be updated when NavigationLoad event is received
         self.net_provider.fetch_with_callback(
-            blitz_traits::net::Request::get(url::Url::parse(&target_url).unwrap_or(options.url.clone())),
+            blitz_traits::net::Request::get(
+                url::Url::parse(&target_url).unwrap_or(options.url.clone()),
+            ),
             Box::new(move |result| {
                 let (url, bytes) = result.unwrap();
                 let contents = std::str::from_utf8(&bytes).unwrap().to_string();

--- a/tests/online_test.rs
+++ b/tests/online_test.rs
@@ -23,5 +23,8 @@ async fn test_load_webpage() {
 
     // Verify we got content
     let h1_elements = doc.query_selector_all("h1").unwrap();
-    assert!(!h1_elements.is_empty(), "Should have loaded example.com with h1 elements");
+    assert!(
+        !h1_elements.is_empty(),
+        "Should have loaded example.com with h1 elements"
+    );
 }


### PR DESCRIPTION
## Summary
- add cachix-backed nix CI workflow that runs on pull requests to master
- expose scripts/ci.sh via nix run .#ci and ensure dav1d is available in devshell
- keep CI pipeline limited to fmt/check/clippy/tests

## Testing
- nix run .#ci